### PR TITLE
Update gem dependencies.

### DIFF
--- a/dullard.gemspec
+++ b/dullard.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Dullard::VERSION
 
-  gem.add_development_dependency "rspec", "~> 2.6"
-  gem.add_dependency "nokogiri", "~> 1.5"
-  gem.add_dependency "rubyzip", "~> 0.9.6"
+  gem.add_development_dependency "rspec", "~> 2.14.1"
+  gem.add_dependency "nokogiri", "~> 1.6.1"
+  gem.add_dependency "rubyzip", "~> 1.1.2"
 end


### PR DESCRIPTION
Hi all, 

I though it might be useful to upgrade the gem which are dullard's dependencies. In my specific case, I have a conflict with another gem I use (axlsx) that requires rubyzip as well. Unfortunately, dullard is preventing me from using the latest version of rubyzip.

Let me know if this is enough as a reason to upgrade the gem, I hope so. :)
