### PR TITLE
Rename 'Time' struct to allow use with Sprockets.

### DIFF
--- a/lib/dullard/reader.rb
+++ b/lib/dullard/reader.rb
@@ -7,7 +7,7 @@ module Dullard
   SharedStringPath = 'xl/sharedStrings.xml'
   StylesPath = 'xl/styles.xml'
 
-  class Time < Struct.new('DullTime', :hours, :minutes, :seconds)
+  class Time < Struct.new(:hours, :minutes, :seconds)
   end
 
 end

--- a/lib/dullard/reader.rb
+++ b/lib/dullard/reader.rb
@@ -7,7 +7,7 @@ module Dullard
   SharedStringPath = 'xl/sharedStrings.xml'
   StylesPath = 'xl/styles.xml'
 
-  class Time < Struct.new('Time', :hours, :minutes, :seconds)
+  class Time < Struct.new('DullTime', :hours, :minutes, :seconds)
   end
 
 end


### PR DESCRIPTION
I had a rather painful issue recently where Dullard (specifically, its recent support for Time) broke rails (specifically, sprockets that ships with Rails 4.1 and 4.2).

As it happens, the Sprockets shipped with Rails makes a few classes via `class Foo < Struct(...)`, and within those classes then refer to `Time.parse` for asset times.

Unfortunately, those classes being in `Struct::` means that `Time` refers now to the `Struct::Time` that Dullard creates.

The class encapsulation of `Dullard::Time` isn't leaking, so that doesn't need to change -- just the name defined for the Struct.

... I think. :) I sand-blasted that soup cracker in my master branch by renaming everything, and that's what I'm using atm; I'll follow up when I can. Thanks again for a great lib.